### PR TITLE
Fix parameter doc comments

### DIFF
--- a/Sources/ConcurrencyExtras/ActorIsolated.swift
+++ b/Sources/ConcurrencyExtras/ActorIsolated.swift
@@ -79,7 +79,7 @@ public final actor ActorIsolated<Value> {
   /// > await didOpenSettings.withValue { XCTAssertTrue($0) }
   /// > ```
   ///
-  /// - Parameters: operation: An operation to be performed on the actor with the underlying value.
+  /// - Parameter operation: An operation to be performed on the actor with the underlying value.
   /// - Returns: The result of the operation.
   public func withValue<T>(
     _ operation: @Sendable (inout Value) throws -> T

--- a/Sources/ConcurrencyExtras/LockIsolated.swift
+++ b/Sources/ConcurrencyExtras/LockIsolated.swift
@@ -36,7 +36,7 @@ public final class LockIsolated<Value>: @unchecked Sendable {
   /// }
   /// ```
   ///
-  /// - Parameters: operation: An operation to be performed on the the underlying value with a lock.
+  /// - Parameter operation: An operation to be performed on the the underlying value with a lock.
   /// - Returns: The result of the operation.
   public func withValue<T: Sendable>(
     _ operation: (inout Value) throws -> T


### PR DESCRIPTION
The `Parameters`, with the "s", doc comment only works if the parameter labels are on separate lines.

| Before | After |
| -------| ----- |
| <img width="512" alt="Screenshot 2023-09-19 at 9 55 28 AM" src="https://github.com/pointfreeco/swift-concurrency-extras/assets/91548783/f263736e-5288-42cf-aa18-6ff3710aae3b"> | <img width="513" alt="Screenshot 2023-09-19 at 9 55 40 AM" src="https://github.com/pointfreeco/swift-concurrency-extras/assets/91548783/e996fcfa-ea79-4fad-b18c-399be811afbb"> |
