### PR TITLE
Add reasync initializer to `Result`

### DIFF
--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,0 +1,14 @@
+extension Result where Failure == Swift.Error {
+  /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
+  /// a success, or any thrown error as a failure.
+  ///
+  /// - Parameter body: A throwing closure to evaluate.
+  @_transparent
+  public init(catching body: () async throws -> Success) async {
+    do {
+      self = .success(try await body())
+    } catch {
+      self = .failure(error)
+    }
+  }
+}


### PR DESCRIPTION
It can be handy to wrap up some async throwing work into the `Result` type, so till `reasync` is a thing this library can provide a helper.