### PR TITLE
Annotate `Result.init(catching:)` closure parameter as `@Sendable`

### DIFF
--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -4,7 +4,7 @@ extension Result where Failure == Swift.Error {
   ///
   /// - Parameter body: A throwing closure to evaluate.
   @_transparent
-  public init(catching body: () async throws -> Success) async {
+  public init(catching body: @Sendable () async throws -> Success) async {
     do {
       self = .success(try await body())
     } catch {

--- a/Tests/ConcurrencyExtrasTests/ResultInitTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultInitTests.swift
@@ -1,0 +1,26 @@
+import ConcurrencyExtras
+import XCTest
+
+final class ResultInitTests: XCTestCase {
+  func testIntFactory() async {
+    let zero = await IntFactory().zero()
+    switch zero {
+    case .success(let success):
+      XCTAssertEqual(success, 0)
+    case .failure(let failure):
+      XCTFail(failure.localizedDescription)
+    }
+  }
+}
+
+func makeInt(closure: @escaping () async throws -> Int) async throws -> Int {
+  try await closure()
+}
+
+actor IntFactory {
+  func zero() async -> Result<Int, Error> {
+    await Result {
+      try await makeInt { 0 }
+    }
+  }
+}


### PR DESCRIPTION
The following example previously produced some diagnostics:

```swift
func makeInt(closure: @escaping () async throws -> Int) async throws -> Int {
  try await closure()
}

actor IntFactory {
  func zero() async -> Result<Int, Error> {
    await Result {
                 ^ warning: passing argument of non-sendable type '() async throws -> Int' outside of actor-isolated context may introduce data races
                 ^ note: a function type must be marked '@Sendable' to conform to 'Sendable'
      try await makeInt { 0 }
    }
  }
}
```