### PR TITLE
Soft-deprecate `UncheckedSendable` on Swift 5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Reliably testable Swift concurrency.
       * [`ActorIsolated` and `LockIsolated`](#actorisolated-and-lockisolated)
       * [Streams](#streams)
       * [Tasks](#tasks)
-      * [`UncheckedSendable`](#uncheckedsendable)
       * [Serial execution](#serial-execution)
   * [Documentation](#documentation)
   * [Other libraries](#other-libraries)
@@ -140,17 +139,6 @@ The library enhances the `Task` type with new functionality.
     suspending the current task a number of times and improve the odds that other async work has
     enough time to start. Prefer the reliability of [serial execution](#serial-execution) instead
     where possible.
-
-### `UncheckedSendable`
-
-A wrapper type that can make any type `Sendable`, but in an unsafe and unchecked way. This type
-should only be used as an alternative to `@preconcurrency import`, which turns off concurrency
-checks for everything in the library. Whereas `UncheckedSendable` allows you to turn off concurrency
-warnings for just one single usage of a particular type.
-
-While [SE-0302][se-0302] mentions future work of ["Adaptor Types for Legacy
-Codebases"][se-0302-unsafetransfer], including an `UnsafeTransfer` type that serves the same
-purpose, it has not landed in Swift.
 
 ### Serial execution
 

--- a/Sources/ConcurrencyExtras/UncheckedSendable.swift
+++ b/Sources/ConcurrencyExtras/UncheckedSendable.swift
@@ -12,6 +12,12 @@
 ///
 /// To synchronously isolate a value with a lock, see ``LockIsolated``. To asynchronously isolated a
 /// value on an actor, see ``ActorIsolated``.
+#if swift(>=5.10)
+  @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+#endif
 @dynamicMemberLookup
 @propertyWrapper
 public struct UncheckedSendable<Value>: @unchecked Sendable {
@@ -49,9 +55,28 @@ public struct UncheckedSendable<Value>: @unchecked Sendable {
   }
 }
 
+#if swift(>=5.10)
+  @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+#endif
 extension UncheckedSendable: Equatable where Value: Equatable {}
+
+#if swift(>=5.10)
+  @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+#endif
 extension UncheckedSendable: Hashable where Value: Hashable {}
 
+#if swift(>=5.10)
+  @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+#endif
 extension UncheckedSendable: Decodable where Value: Decodable {
   public init(from decoder: Decoder) throws {
     do {
@@ -63,6 +88,12 @@ extension UncheckedSendable: Decodable where Value: Decodable {
   }
 }
 
+#if swift(>=5.10)
+  @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(tvOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+  @available(watchOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")
+#endif
 extension UncheckedSendable: Encodable where Value: Encodable {
   public func encode(to encoder: Encoder) throws {
     do {


### PR DESCRIPTION
5.10's `nonisolated(unsafe) let` is a replacement for `UncheckedSendable`, so we can soft-deprecate and de-emphasize it.