### PR TITLE
Add `AnyHashableSendable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This library comes with a number of tools that make working with Swift concurren
 testable.
 
   * [`LockIsolated`](#lockisolated)
+  * [`AnyHashableSendable`](#anyhashablesendable)
   * [Streams](#streams)
   * [Tasks](#tasks)
   * [Serial execution](#serial-execution)
@@ -43,6 +44,11 @@ testable.
 
 The `LockIsolated` type helps wrap other values in an isolated context. It wraps the value in a 
 class with a lock, which allows you to read and write the value with a synchronous interface.
+
+### `AnyHashableSendable`
+
+The `AnyHashableSendable` type is a type-erased wrapper like `AnyHashable` that preserves the
+sendability of the underlying value.
 
 ### Streams
 

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -1,0 +1,23 @@
+/// A type-erased hashable, sendable value.
+///
+/// A sendable version of `AnyHashable` that is useful in working around the limitation that an
+/// existential `any Hashable` does not conform to `Hashable`.
+public struct AnyHashableSendable: Hashable, Sendable {
+  public let base: any Hashable & Sendable
+
+  /// Creates a type-erased hashable, sendable value that wraps the given instance.
+  public init(_ base: some Hashable & Sendable) {
+    self.base = base
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    func open<T: Equatable>(_ lhs: T) -> Bool {
+      lhs == rhs as? T
+    }
+    return open(lhs)
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(base)
+  }
+}

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -15,10 +15,7 @@ public struct AnyHashableSendable: Hashable, Sendable {
   }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    func open<T: Equatable>(_ lhs: T) -> Bool {
-      lhs == rhs.base as? T
-    }
-    return open(lhs.base)
+    AnyHashable(lhs.base) == AnyHashable(rhs.base)
   }
 
   public func hash(into hasher: inout Hasher) {

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -21,3 +21,20 @@ public struct AnyHashableSendable: Hashable, Sendable {
     hasher.combine(base)
   }
 }
+
+extension AnyHashableSendable: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    "AnyHashableSendable(" + String(reflecting: base) + ")"
+  }
+}
+extension AnyHashableSendable: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(self, children: ["value": base])
+  }
+}
+
+extension AnyHashableSendable: CustomStringConvertible {
+  public var description: String {
+    String(describing: base)
+  }
+}

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -31,6 +31,7 @@ extension AnyHashableSendable: CustomDebugStringConvertible {
     "AnyHashableSendable(" + String(reflecting: base) + ")"
   }
 }
+
 extension AnyHashableSendable: CustomReflectable {
   public var customMirror: Mirror {
     Mirror(self, children: ["value": base])

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -7,14 +7,18 @@ public struct AnyHashableSendable: Hashable, Sendable {
 
   /// Creates a type-erased hashable, sendable value that wraps the given instance.
   public init(_ base: some Hashable & Sendable) {
-    self.base = base
+    if let base = base as? AnyHashableSendable {
+      self = base
+    } else {
+      self.base = base
+    }
   }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     func open<T: Equatable>(_ lhs: T) -> Bool {
-      lhs == rhs as? T
+      lhs == rhs.base as? T
     }
-    return open(lhs)
+    return open(lhs.base)
   }
 
   public func hash(into hasher: inout Hasher) {

--- a/Sources/ConcurrencyExtras/Documentation.docc/ConcurrencyExtras.md
+++ b/Sources/ConcurrencyExtras/Documentation.docc/ConcurrencyExtras.md
@@ -236,6 +236,7 @@ need to make weaker assertions due to non-determinism, but can still assert on s
 ### Data races
 
 - ``LockIsolated``
+- ``AnyHashableSendable``
 
 ### Serial execution
 

--- a/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
@@ -1,0 +1,19 @@
+import ConcurrencyExtras
+import XCTest
+
+@available(*, deprecated)
+final class AnyHashableSendableTests: XCTestCase {
+  func testBasics() {
+    XCTAssertEqual(AnyHashableSendable(1), AnyHashableSendable(1))
+    XCTAssertNotEqual(AnyHashableSendable(1), AnyHashableSendable(2))
+
+    func make(_ base: some Hashable & Sendable) -> AnyHashableSendable {
+      AnyHashableSendable(base)
+    }
+
+    let flat = make(1)
+    let nested = make(flat)
+
+    XCTAssertEqual(flat, nested)
+  }
+}

--- a/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
@@ -1,7 +1,6 @@
 import ConcurrencyExtras
 import XCTest
 
-@available(*, deprecated)
 final class AnyHashableSendableTests: XCTestCase {
   func testBasics() {
     XCTAssertEqual(AnyHashableSendable(1), AnyHashableSendable(1))


### PR DESCRIPTION
We've created this type internally in a few libraries now, so this seems like the perfect place to unify things.