### PR TITLE
Remove Sendable requirements in LockIsolated

### DIFF
--- a/Sources/ConcurrencyExtras/LockIsolated.swift
+++ b/Sources/ConcurrencyExtras/LockIsolated.swift
@@ -16,7 +16,7 @@ public final class LockIsolated<Value>: @unchecked Sendable {
     self._value = try value()
   }
 
-  public subscript<Subject: Sendable>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
+  public subscript<Subject>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
     self.lock.sync {
       self._value[keyPath: keyPath]
     }
@@ -38,7 +38,7 @@ public final class LockIsolated<Value>: @unchecked Sendable {
   ///
   /// - Parameter operation: An operation to be performed on the the underlying value with a lock.
   /// - Returns: The result of the operation.
-  public func withValue<T: Sendable>(
+  public func withValue<T>(
     _ operation: @Sendable (inout Value) throws -> T
   ) rethrows -> T {
     try self.lock.sync {
@@ -84,7 +84,7 @@ public final class LockIsolated<Value>: @unchecked Sendable {
   }
 }
 
-extension LockIsolated where Value: Sendable {
+extension LockIsolated {
   /// The lock-isolated value.
   public var value: Value {
     self.lock.sync {


### PR DESCRIPTION
I don't see the point of requiring Sendable conformance here, as we can instantiate the `LockIsolated` without it

```swift
let timer: LockIsolated<Timer?> = .init(nil) // OK
timer.setValue(newValue) // OK
timer.value // Conformance of 'Timer' to 'Sendable' is unavailable
```

In the meantime, I use this workaround 
```swift
public extension LockIsolated {
    @available(*, deprecated, message: "Waiting for PR")
    var _value: Value {
        self.withValue { UncheckedSendable($0) }.value
    }
}
```