### PR TITLE
`UncheckedSendable: AsyncSequence`

### DIFF
--- a/Sources/ConcurrencyExtras/AsyncStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncStream.swift
@@ -71,7 +71,7 @@ extension AsyncStream {
     }
   }
 
-  @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  @available(*, deprecated, message: "Explicitly wrap the given async sequence with 'UncheckedSendable' first.")
   @_disfavoredOverload
   public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
     self.init(UncheckedSendable(sequence))
@@ -101,7 +101,7 @@ extension AsyncSequence {
     AsyncStream(self)
   }
 
-  @available(*, deprecated, message: "Explicitly wrap this sequence in 'UncheckedSendable' before erasing to stream.")
+  @available(*, deprecated, message: "Explicitly wrap this async sequence with 'UncheckedSendable' before erasing to stream.")
   public func eraseToStream() -> AsyncStream<Element> {
     AsyncStream(UncheckedSendable(self))
   }

--- a/Sources/ConcurrencyExtras/AsyncStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncStream.swift
@@ -72,6 +72,7 @@ extension AsyncStream {
   }
 
   @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  @_disfavoredOverload
   public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
     self.init(UncheckedSendable(sequence))
   }

--- a/Sources/ConcurrencyExtras/AsyncStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncStream.swift
@@ -71,6 +71,11 @@ extension AsyncStream {
     }
   }
 
+  @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+    self.init(UncheckedSendable(sequence))
+  }
+
   /// An `AsyncStream` that never emits and never completes unless cancelled.
   public static var never: Self {
     Self { _ in }
@@ -93,5 +98,10 @@ extension AsyncSequence {
   )
   public func eraseToStream() -> AsyncStream<Element> where Self: Sendable {
     AsyncStream(self)
+  }
+
+  @available(*, deprecated, message: "Explicitly wrap this sequence in 'UncheckedSendable' before erasing to stream.")
+  public func eraseToStream() -> AsyncStream<Element> {
+    AsyncStream(UncheckedSendable(self))
   }
 }

--- a/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
@@ -26,6 +26,11 @@ extension AsyncThrowingStream where Failure == Error {
     }
   }
 
+  @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+    self.init(UncheckedSendable(sequence))
+  }
+
   /// An `AsyncThrowingStream` that never emits and never completes unless cancelled.
   public static var never: Self {
     Self { _ in }
@@ -52,5 +57,10 @@ extension AsyncSequence {
   )
   public func eraseToThrowingStream() -> AsyncThrowingStream<Element, Error> where Self: Sendable {
     AsyncThrowingStream(self)
+  }
+
+  @available(*, deprecated, message: "Explicitly wrap this sequence in 'UncheckedSendable' before erasing to throwing stream.")
+  public func eraseToThrowingStream() -> AsyncThrowingStream<Element, Error> {
+    AsyncThrowingStream(UncheckedSendable(self))
   }
 }

--- a/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
@@ -26,7 +26,7 @@ extension AsyncThrowingStream where Failure == Error {
     }
   }
 
-  @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  @available(*, deprecated, message: "Explicitly wrap the given async sequence with 'UncheckedSendable' first.")
   @_disfavoredOverload
   public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
     self.init(UncheckedSendable(sequence))
@@ -60,7 +60,7 @@ extension AsyncSequence {
     AsyncThrowingStream(self)
   }
 
-  @available(*, deprecated, message: "Explicitly wrap this sequence in 'UncheckedSendable' before erasing to throwing stream.")
+  @available(*, deprecated, message: "Explicitly wrap this async sequence with 'UncheckedSendable' before erasing to throwing stream.")
   public func eraseToThrowingStream() -> AsyncThrowingStream<Element, Error> {
     AsyncThrowingStream(UncheckedSendable(self))
   }

--- a/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
+++ b/Sources/ConcurrencyExtras/AsyncThrowingStream.swift
@@ -27,6 +27,7 @@ extension AsyncThrowingStream where Failure == Error {
   }
 
   @available(*, deprecated, message: "Explicitly wrap given sequence in 'UncheckedSendable'.")
+  @_disfavoredOverload
   public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
     self.init(UncheckedSendable(sequence))
   }

--- a/Sources/ConcurrencyExtras/UncheckedSendable.swift
+++ b/Sources/ConcurrencyExtras/UncheckedSendable.swift
@@ -55,6 +55,12 @@ public struct UncheckedSendable<Value>: @unchecked Sendable {
   }
 }
 
+extension UncheckedSendable: AsyncSequence where Value: AsyncSequence {
+  public func makeAsyncIterator() -> Value.AsyncIterator {
+    value.makeAsyncIterator()
+  }
+}
+
 #if swift(>=5.10)
   @available(iOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead.")@available(
     macOS, deprecated: 9999, message: "Use 'nonisolated(unsafe) let', instead."

--- a/Sources/ConcurrencyExtras/UncheckedSendable.swift
+++ b/Sources/ConcurrencyExtras/UncheckedSendable.swift
@@ -56,7 +56,10 @@ public struct UncheckedSendable<Value>: @unchecked Sendable {
 }
 
 extension UncheckedSendable: AsyncSequence where Value: AsyncSequence {
-  public func makeAsyncIterator() -> Value.AsyncIterator {
+  public typealias AsyncIterator = Value.AsyncIterator
+  public typealias Element = Value.Element
+
+  public func makeAsyncIterator() -> AsyncIterator {
     value.makeAsyncIterator()
   }
 }

--- a/Tests/ConcurrencyExtrasTests/AsyncStreamTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AsyncStreamTests.swift
@@ -4,33 +4,41 @@
 
   @available(iOS 15, *)
   private let sendable: @Sendable () async -> AsyncStream<Void> = {
-    NotificationCenter.default
-      .notifications(named: UIApplication.userDidTakeScreenshotNotification)
-      .map { _ in }
-      .eraseToStream()
+    UncheckedSendable(
+      NotificationCenter.default
+        .notifications(named: UIApplication.userDidTakeScreenshotNotification)
+        .map { _ in }
+    )
+    .eraseToStream()
   }
 
   @available(iOS 15, *)
   private let mainActor: @MainActor () -> AsyncStream<Void> = {
-    NotificationCenter.default
-      .notifications(named: UIApplication.userDidTakeScreenshotNotification)
-      .map { _ in }
-      .eraseToStream()
+    UncheckedSendable(
+      NotificationCenter.default
+        .notifications(named: UIApplication.userDidTakeScreenshotNotification)
+        .map { _ in }
+    )
+    .eraseToStream()
   }
 
   @available(iOS 15, *)
   private let sendableThrowing: @Sendable () async -> AsyncThrowingStream<Void, Error> = {
-    NotificationCenter.default
-      .notifications(named: UIApplication.userDidTakeScreenshotNotification)
-      .map { _ in }
-      .eraseToThrowingStream()
+    UncheckedSendable(
+      NotificationCenter.default
+        .notifications(named: UIApplication.userDidTakeScreenshotNotification)
+        .map { _ in }
+    )
+    .eraseToThrowingStream()
   }
 
   @available(iOS 15, *)
   private let mainActorThrowing: @MainActor () -> AsyncThrowingStream<Void, Error> = {
-    NotificationCenter.default
-      .notifications(named: UIApplication.userDidTakeScreenshotNotification)
-      .map { _ in }
-      .eraseToThrowingStream()
+    UncheckedSendable(
+      NotificationCenter.default
+        .notifications(named: UIApplication.userDidTakeScreenshotNotification)
+        .map { _ in }
+    )
+    .eraseToThrowingStream()
   }
 #endif

--- a/Tests/ConcurrencyExtrasTests/AsyncStreamTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AsyncStreamTests.swift
@@ -13,6 +13,17 @@
   }
 
   @available(iOS 15, *)
+  private let sendableInitializer: @Sendable () async -> AsyncStream<Void> = {
+    AsyncStream(
+      UncheckedSendable(
+        NotificationCenter.default
+          .notifications(named: UIApplication.userDidTakeScreenshotNotification)
+          .map { _ in }
+      )
+    )
+  }
+
+  @available(iOS 15, *)
   private let mainActor: @MainActor () -> AsyncStream<Void> = {
     UncheckedSendable(
       NotificationCenter.default


### PR DESCRIPTION
Currently, a non-sendable sequence cannot be erased to `AsyncStream` using this library's initializers even if one takes care to traffic it through via `nonisolated(unsafe)`:

```swift
nonisolated(unsafe) let nonSendable = nonSendable
AsyncStream(nonSendable)  // 🛑
```

This conditional conformance acts as a workaround:

```swift
AsyncStream(UncheckedSendable(nonSendable))
```

Ideally folks can stop using our concrete async sequence eraser in favor of `any AsyncSequence<Element, Failure>`, but this requires a minimum deployment target of iOS 18, so it won't be an option for many people for some time.