### PR TITLE
Use isolated(any) instead of Sendable for withMainSerialExecutor async operation

### DIFF
--- a/Sources/ConcurrencyExtras/MainSerialExecutor.swift
+++ b/Sources/ConcurrencyExtras/MainSerialExecutor.swift
@@ -27,6 +27,17 @@
   /// > during the operation.
   ///
   /// - Parameter operation: An operation to be performed on the main serial executor.
+  #if compiler(>=6)
+  @MainActor
+  public func withMainSerialExecutor(
+    @_implicitSelfCapture operation: @isolated(any) () async throws -> Void
+  ) async rethrows {
+    let didUseMainSerialExecutor = uncheckedUseMainSerialExecutor
+    defer { uncheckedUseMainSerialExecutor = didUseMainSerialExecutor }
+    uncheckedUseMainSerialExecutor = true
+    try await operation()
+  }
+  #else
   @MainActor
   public func withMainSerialExecutor(
     @_implicitSelfCapture operation: @Sendable () async throws -> Void
@@ -36,6 +47,7 @@
     uncheckedUseMainSerialExecutor = true
     try await operation()
   }
+  #endif
 
   /// Perform an operation on the main serial executor.
   ///


### PR DESCRIPTION
When working with a MainActor isolated type inside the async operation closure for `withMainSerialExecutor`, the context was not being inferred as MainActor isolated. This can be easily demonstrated like this:

```swift
@MainActor
final class Foo {
    func sleep() async {
        try? await Task.sleep(for: .seconds(1))
    }
}

final class MainSerialExecutorActor: XCTestCase {
    @MainActor
    func testWithMainSerialExecutor() async {
        await withMainSerialExecutor {
            let foo = Foo() // ❌ Expression is 'async' but is not marked with 'await'
            await foo.sleep()
        }
    }
}
```

This only started happening after the change in #28. 

@stephencelis pointed out on Slack that this can be resolved by using `@isolated(any)` instead of `@Sendable` on `withMainSerialExecutor`'s `operation` closure. Locally this resolves the issue on my end.