### PR TITLE
`AnyHashableSendable` ergonomics

### DIFF
--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -6,12 +6,18 @@ public struct AnyHashableSendable: Hashable, Sendable {
   public let base: any Hashable & Sendable
 
   /// Creates a type-erased hashable, sendable value that wraps the given instance.
+  @_disfavoredOverload
   public init(_ base: any Hashable & Sendable) {
     if let base = base as? AnyHashableSendable {
       self = base
     } else {
       self.base = base
     }
+  }
+
+  /// Creates a type-erased hashable, sendable value that wraps the given instance.
+  public init(_ base: some Hashable & Sendable) {
+    self.init(base)
   }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -8,16 +8,16 @@ public struct AnyHashableSendable: Hashable, Sendable {
   /// Creates a type-erased hashable, sendable value that wraps the given instance.
   @_disfavoredOverload
   public init(_ base: any Hashable & Sendable) {
+    self.init(base)
+  }
+
+  /// Creates a type-erased hashable, sendable value that wraps the given instance.
+  public init(_ base: some Hashable & Sendable) {
     if let base = base as? AnyHashableSendable {
       self = base
     } else {
       self.base = base
     }
-  }
-
-  /// Creates a type-erased hashable, sendable value that wraps the given instance.
-  public init(_ base: some Hashable & Sendable) {
-    self.init(base)
   }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -6,7 +6,7 @@ public struct AnyHashableSendable: Hashable, Sendable {
   public let base: any Hashable & Sendable
 
   /// Creates a type-erased hashable, sendable value that wraps the given instance.
-  public init(_ base: some Hashable & Sendable) {
+  public init(_ base: any Hashable & Sendable) {
     if let base = base as? AnyHashableSendable {
       self = base
     } else {
@@ -38,5 +38,11 @@ extension AnyHashableSendable: CustomReflectable {
 extension AnyHashableSendable: CustomStringConvertible {
   public var description: String {
     String(describing: base)
+  }
+}
+
+extension AnyHashableSendable: _HasCustomAnyHashableRepresentation {
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    base as? AnyHashable
   }
 }

--- a/Sources/ConcurrencyExtras/AnyHashableSendable.swift
+++ b/Sources/ConcurrencyExtras/AnyHashableSendable.swift
@@ -46,3 +46,27 @@ extension AnyHashableSendable: _HasCustomAnyHashableRepresentation {
     base as? AnyHashable
   }
 }
+
+extension AnyHashableSendable: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) {
+    self.init(value)
+  }
+}
+
+extension AnyHashableSendable: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Double) {
+    self.init(value)
+  }
+}
+
+extension AnyHashableSendable: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int) {
+    self.init(value)
+  }
+}
+
+extension AnyHashableSendable: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}

--- a/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
@@ -15,4 +15,14 @@ final class AnyHashableSendableTests: XCTestCase {
 
     XCTAssertEqual(flat, nested)
   }
+
+  func testExistential() {
+    let base: (any Hashable & Sendable)? = 1
+    let wrapped = base.map(AnyHashableSendable.init)
+    XCTAssertEqual(wrapped, AnyHashableSendable(1))
+  }
+
+  func testAnyHashable() {
+    XCTAssertEqual(AnyHashableSendable(1), 1 as AnyHashable)
+  }
 }

--- a/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
+++ b/Tests/ConcurrencyExtrasTests/AnyHashableSendableTests.swift
@@ -25,4 +25,15 @@ final class AnyHashableSendableTests: XCTestCase {
   func testAnyHashable() {
     XCTAssertEqual(AnyHashableSendable(1), 1 as AnyHashable)
   }
+
+  func testLiterals() {
+    XCTAssertEqual(AnyHashableSendable(true), true)
+    XCTAssertEqual(AnyHashableSendable(1), 1)
+    XCTAssertEqual(AnyHashableSendable(4.2), 4.2)
+    XCTAssertEqual(AnyHashableSendable("Blob"), "Blob")
+
+    let bool: AnyHashableSendable = true
+    XCTAssertEqual(bool.base as? Bool, true)
+    XCTAssertEqual(bool as AnyHashable as? Bool, true)
+  }
 }


### PR DESCRIPTION
While working with this type I noticed a few deficiencies:

  - First, the initializer takes an opaque type rather than an existential, and while existentials are typically automatically opened, there are cases in which this initializer will fail, _e.g._:

    ```swift
    let x: (any Hashable & Sendable)?
    x.map(AnyHashableSendable.init)  // 🛑
    ```

    We can fix this by updating the initializer to be an `any` already.

  - Second, comparing an `AnyHashableSendable` with another `AnyHashable` fails because of the underlying type, but there is an underscored public protocol in the standard library we can take advantage of that is called when a hashable type is cast to `AnyHashable`, and if we return the base value then things like this start to work:

    ```swift
    AnyHashableSendable(1) == 1 as AnyHashable  // true
    ```

  - Third, while probably not common in practice, we can box up certain literals into `AnyHashableSendable` automatically, so let's do it. I do _not_ think it's possible to box array or dictionary literals, but we can cover the more common cases.