### PR TITLE
Support typed throws

### DIFF
--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,31 +1,27 @@
 #if compiler(>=6)
-extension Result {
-  /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
-  /// a success, or any thrown error as a failure.
-  ///
-  /// - Parameter body: A throwing closure to evaluate.
-  @_transparent
-  public init(catching body: () async throws(Failure) -> Success) async {
-    do {
-      self = .success(try await body())
-    } catch {
-      self = .failure(error)
+  extension Result {
+    /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
+    /// a success, or any thrown error as a failure.
+    ///
+    /// - Parameter body: A throwing closure to evaluate.
+    @_transparent
+    public init(catching body: () async throws(Failure) -> Success) async {
+      do {
+        self = .success(try await body())
+      } catch {
+        self = .failure(error)
+      }
     }
   }
-}
 #else
-extension Result where Failure == Swift.Error {
-  /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
-  /// a success, or any thrown error as a failure.
-  ///
-  /// - Parameter body: A throwing closure to evaluate.
-  @_transparent
-  public init(catching body: () async throws -> Success) async {
-    do {
-      self = .success(try await body())
-    } catch {
-      self = .failure(error)
+  extension Result where Failure == Swift.Error {
+    @_transparent
+    public init(catching body: () async throws -> Success) async {
+      do {
+        self = .success(try await body())
+      } catch {
+        self = .failure(error)
+      }
     }
   }
-}
 #endif

--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,4 +1,4 @@
-extension Result where Failure: Swift.Error {
+extension Result {
   /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
   /// a success, or any thrown error as a failure.
   ///

--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,3 +1,4 @@
+#if compiler(>=6)
 extension Result {
   /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
   /// a success, or any thrown error as a failure.
@@ -12,3 +13,19 @@ extension Result {
     }
   }
 }
+#else
+extension Result where Failure == Swift.Error {
+  /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
+  /// a success, or any thrown error as a failure.
+  ///
+  /// - Parameter body: A throwing closure to evaluate.
+  @_transparent
+  public init(catching body: () async throws -> Success) async {
+    do {
+      self = .success(try await body())
+    } catch {
+      self = .failure(error)
+    }
+  }
+}
+#endif

--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,10 +1,10 @@
-extension Result where Failure == Swift.Error {
+extension Result where Failure: Swift.Error {
   /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
   /// a success, or any thrown error as a failure.
   ///
   /// - Parameter body: A throwing closure to evaluate.
   @_transparent
-  public init(catching body: () async throws -> Success) async {
+  public init(catching body: () async throws(Failure) -> Success) async {
     do {
       self = .success(try await body())
     } catch {

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -11,7 +11,7 @@ final class ResultTests: XCTestCase {
     }
   }
 
-  func testBasics() async throws {
+  func testBasics() async {
     do {
       let res = await Result { try await f(42) }
       XCTAssertEqual(try res.get(), 42)
@@ -28,17 +28,16 @@ final class ResultTests: XCTestCase {
     }
   }
 
-#if compiler(>=6)
-  func g(_ value: Int) async throws(SomeError) -> Int {
-    if value == 42 {
-      return 42
-    } else {
-      throw SomeError()
+  #if compiler(>=6)
+    func g(_ value: Int) async throws(SomeError) -> Int {
+      if value == 42 {
+        return 42
+      } else {
+        throw SomeError()
+      }
     }
-  }
 
-  func testTypedThrows() async throws {
-    do {
+    func testTypedThrows() async {
       let res = await Result { () async throws(SomeError) -> Int in try await g(0) }
       do {
         _ = try res.get()
@@ -46,6 +45,18 @@ final class ResultTests: XCTestCase {
         XCTAssertEqual(error, SomeError())
       }
     }
-  }
-#endif
+
+    func h() async throws(SomeError) -> Int {
+      throw SomeError()
+    }
+
+    func testTypedThrowsInference() async {
+      let res = await Result(catching: h)
+      do {
+        _ = try res.get()
+      } catch {
+        XCTAssertEqual(error, SomeError())
+      }
+    }
+  #endif
 }

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -1,0 +1,49 @@
+import ConcurrencyExtras
+import XCTest
+
+final class ResultTests: XCTestCase {
+  struct SomeError: Error, Equatable { }
+  func f(_ value: Int) async throws -> Int {
+    if value == 42 {
+      return 42
+    } else {
+      throw SomeError()
+    }
+  }
+
+  func testBasics() async throws {
+    do {
+      let res = await Result { try await f(42) }
+      XCTAssertEqual(try res.get(), 42)
+    }
+    do {
+      let res = await Result { try await f(0) }
+      do {
+        _ = try res.get()
+      } catch let error as SomeError {
+        XCTAssertEqual(error, SomeError())
+      } catch {
+        XCTFail("unexpected error: \(error)")
+      }
+    }
+  }
+
+  func g(_ value: Int) async throws(SomeError) -> Int {
+    if value == 42 {
+      return 42
+    } else {
+      throw SomeError()
+    }
+  }
+
+  func testTypedThrows() async throws {
+    do {
+      let res = await Result { () async throws(SomeError) -> Int in try await g(0) }
+      do {
+        _ = try res.get()
+      } catch {
+        XCTAssertEqual(error, SomeError())
+      }
+    }
+  }
+}

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -28,6 +28,7 @@ final class ResultTests: XCTestCase {
     }
   }
 
+#if compiler(>=6)
   func g(_ value: Int) async throws(SomeError) -> Int {
     if value == 42 {
       return 42
@@ -36,7 +37,6 @@ final class ResultTests: XCTestCase {
     }
   }
 
-#if compiler(>=6)
   func testTypedThrows() async throws {
     do {
       let res = await Result { () async throws(SomeError) -> Int in try await g(0) }

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -36,6 +36,7 @@ final class ResultTests: XCTestCase {
     }
   }
 
+#if compiler(>=6)
   func testTypedThrows() async throws {
     do {
       let res = await Result { () async throws(SomeError) -> Int in try await g(0) }
@@ -46,4 +47,5 @@ final class ResultTests: XCTestCase {
       }
     }
   }
+#endif
 }


### PR DESCRIPTION
We've started adopting typed throws in a couple of areas and I noticed that my `Result` extension to handle `async` closures was clashing with the one in this package. The difference is subtle but I _think_ this is a more general way to do this extension.

As the test shows, this allows you to convert an `async throws(SomeError)` into a `Result<T, SomeError>`. Without this change, the resulting type is `Result<T, any Error>` instead.