### PR TITLE
`nonisolated(nonsending)` Result `init`

### DIFF
--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6)
+#if compiler(>=6.2)
   extension Result {
     /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
     /// a success, or any thrown error as a failure.
@@ -7,6 +7,23 @@
     @_transparent
     public nonisolated(nonsending) init(
       catching body: nonisolated(nonsending) () async throws(Failure) -> Success
+    ) async {
+      do {
+        self = .success(try await body())
+      } catch {
+        self = .failure(error)
+      }
+    }
+  }
+#elseif compiler(>=6)
+  extension Result {
+    /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
+    /// a success, or any thrown error as a failure.
+    ///
+    /// - Parameter body: A throwing closure to evaluate.
+    @_transparent
+    public init(
+      catching body: () async throws(Failure) -> Success
     ) async {
       do {
         self = .success(try await body())

--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -5,7 +5,9 @@
     ///
     /// - Parameter body: A throwing closure to evaluate.
     @_transparent
-    public init(catching body: () async throws(Failure) -> Success) async {
+    public nonisolated(nonsending) init(
+      catching body: nonisolated(nonsending) () async throws(Failure) -> Success
+    ) async {
       do {
         self = .success(try await body())
       } catch {

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -1,9 +1,9 @@
 import ConcurrencyExtras
-import XCTest
+import Testing
 
-final class ResultTests: XCTestCase {
+struct ResultTests {
   struct SomeError: Error, Equatable {}
-  nonisolated(nonsending) func f(_ value: Int) async throws -> Int {
+  func f(_ value: Int) async throws -> Int {
     if value == 42 {
       return 42
     } else {
@@ -11,25 +11,25 @@ final class ResultTests: XCTestCase {
     }
   }
 
-  func testBasics() async {
+  @Test func basics() async throws {
     do {
       let res = await Result { try await f(42) }
-      XCTAssertEqual(try res.get(), 42)
+      #expect(try res.get() == 42)
     }
     do {
       let res = await Result { try await f(0) }
       do {
         _ = try res.get()
       } catch let error as SomeError {
-        XCTAssertEqual(error, SomeError())
+        #expect(error == SomeError())
       } catch {
-        XCTFail("unexpected error: \(error)")
+        Issue.record(error, "unexpected error: \(error)")
       }
     }
   }
 
   #if compiler(>=6)
-    nonisolated(nonsending) func g(_ value: Int) async throws(SomeError) -> Int {
+    func g(_ value: Int) async throws(SomeError) -> Int {
       if value == 42 {
         return 42
       } else {
@@ -37,12 +37,12 @@ final class ResultTests: XCTestCase {
       }
     }
 
-    func testTypedThrows() async {
+    @Test func typedThrows() async {
       let res = await Result { () async throws(SomeError) -> Int in try await g(0) }
       do {
         _ = try res.get()
       } catch {
-        XCTAssertEqual(error, SomeError())
+        #expect(error == SomeError())
       }
     }
 
@@ -50,12 +50,12 @@ final class ResultTests: XCTestCase {
       throw SomeError()
     }
 
-    func testTypedThrowsInference() async {
+    @Test func typedThrowsInference() async {
       let res = await Result(catching: h)
       do {
         _ = try res.get()
       } catch {
-        XCTAssertEqual(error, SomeError())
+        #expect(error == SomeError())
       }
     }
   #endif

--- a/Tests/ConcurrencyExtrasTests/ResultTests.swift
+++ b/Tests/ConcurrencyExtrasTests/ResultTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ResultTests: XCTestCase {
   struct SomeError: Error, Equatable {}
-  func f(_ value: Int) async throws -> Int {
+  nonisolated(nonsending) func f(_ value: Int) async throws -> Int {
     if value == 42 {
       return 42
     } else {
@@ -29,7 +29,7 @@ final class ResultTests: XCTestCase {
   }
 
   #if compiler(>=6)
-    func g(_ value: Int) async throws(SomeError) -> Int {
+    nonisolated(nonsending) func g(_ value: Int) async throws(SomeError) -> Int {
       if value == 42 {
         return 42
       } else {


### PR DESCRIPTION
Updates the `Result` initialiser to be `nonisolated(nonsending)`, to remove the need to capture instance properties in TCA26's deprecated `Effect.run` or `store.addTask` to avoid `Sending value of non-Sendable type '() async throws -> Void' risks causing data races` compiler errors.

This has uncovered the need to update `func f` and `func g` in the test suite either to be explicitly `nonisolated(nonsending)` themselves, or better yet, to rewrite the test suite using Swift Testing as a `struct` instead of a non-`Sendable` class. However, I appreciate this could be a breaking change for consumers of the library, so there's obviously a point of discussion to be had here!