### PR TITLE
Enable `NonisolatedNonsendingByDefault`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,3 +36,12 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
 #endif
+
+#if compiler(>=6.2)
+  for target in package.targets {
+    target.swiftSettings = target.swiftSettings ?? []
+    target.swiftSettings! += [
+      .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+    ]
+  }
+#endif

--- a/Sources/ConcurrencyExtras/Result.swift
+++ b/Sources/ConcurrencyExtras/Result.swift
@@ -1,21 +1,4 @@
-#if compiler(>=6.2)
-  extension Result {
-    /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
-    /// a success, or any thrown error as a failure.
-    ///
-    /// - Parameter body: A throwing closure to evaluate.
-    @_transparent
-    public nonisolated(nonsending) init(
-      catching body: nonisolated(nonsending) () async throws(Failure) -> Success
-    ) async {
-      do {
-        self = .success(try await body())
-      } catch {
-        self = .failure(error)
-      }
-    }
-  }
-#elseif compiler(>=6)
+#if compiler(>=6)
   extension Result {
     /// Creates a new result by evaluating an async throwing closure, capturing the returned value as
     /// a success, or any thrown error as a failure.

--- a/Sources/ConcurrencyExtras/Task.swift
+++ b/Sources/ConcurrencyExtras/Task.swift
@@ -1,46 +1,24 @@
 import Foundation
 
-#if compiler(>=6.2)
-  extension Task where Success == Never, Failure == Never {
-    /// Suspends the current task a number of times before resuming with the goal of allowing other
-    /// tasks to start their work.
-    ///
-    /// This function can be used to make flakey async tests less flakey, as described in
-    /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
-    /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
-    /// reliability of async tests, and to make their execution deterministic.
-    public nonisolated(nonsending) static func megaYield(count: Int = _defaultMegaYieldCount) async {
-      // TODO: Investigate why mega yields are still necessary in TCA's test suite.
-      // guard !uncheckedUseMainSerialExecutor else {
-      //   await Task.yield()
-      //   return
-      // }
-      for _ in 0..<count {
-        await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
-      }
+extension Task where Success == Never, Failure == Never {
+  /// Suspends the current task a number of times before resuming with the goal of allowing other
+  /// tasks to start their work.
+  ///
+  /// This function can be used to make flakey async tests less flakey, as described in
+  /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
+  /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
+  /// reliability of async tests, and to make their execution deterministic.
+  public static func megaYield(count: Int = _defaultMegaYieldCount) async {
+    // TODO: Investigate why mega yields are still necessary in TCA's test suite.
+    // guard !uncheckedUseMainSerialExecutor else {
+    //   await Task.yield()
+    //   return
+    // }
+    for _ in 0..<count {
+      await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
     }
   }
-#else
-  extension Task where Success == Never, Failure == Never {
-    /// Suspends the current task a number of times before resuming with the goal of allowing other
-    /// tasks to start their work.
-    ///
-    /// This function can be used to make flakey async tests less flakey, as described in
-    /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
-    /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
-    /// reliability of async tests, and to make their execution deterministic.
-    public static func megaYield(count: Int = _defaultMegaYieldCount) async {
-      // TODO: Investigate why mega yields are still necessary in TCA's test suite.
-      // guard !uncheckedUseMainSerialExecutor else {
-      //   await Task.yield()
-      //   return
-      // }
-      for _ in 0..<count {
-        await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
-      }
-    }
-  }
-#endif
+}
 
 /// The number of yields `Task.megaYield()` invokes by default.
 ///
@@ -53,102 +31,50 @@ public let _defaultMegaYieldCount = max(
   )
 )
 
-#if compiler(>=6.2)
-  extension Task where Failure == Never {
-    /// An async function that never returns.
-    public nonisolated(nonsending) static func never() async throws -> Success {
-      for await element in AsyncStream<Success>.never {
-        return element
-      }
-      throw _Concurrency.CancellationError()
+extension Task where Failure == Never {
+  /// An async function that never returns.
+  public static func never() async throws -> Success {
+    for await element in AsyncStream<Success>.never {
+      return element
     }
+    throw _Concurrency.CancellationError()
   }
+}
 
-  extension Task where Success == Never, Failure == Never {
-    /// An async function that never returns.
-    public nonisolated(nonsending) static func never() async throws {
-      for await _ in AsyncStream<Never>.never {}
-      throw _Concurrency.CancellationError()
-    }
+extension Task where Success == Never, Failure == Never {
+  /// An async function that never returns.
+  public static func never() async throws {
+    for await _ in AsyncStream<Never>.never {}
+    throw _Concurrency.CancellationError()
   }
-#else
-  extension Task where Failure == Never {
-    /// An async function that never returns.
-    public static func never() async throws -> Success {
-      for await element in AsyncStream<Success>.never {
-        return element
-      }
-      throw _Concurrency.CancellationError()
-    }
-  }
+}
 
-  extension Task where Success == Never, Failure == Never {
-    /// An async function that never returns.
-    public static func never() async throws {
-      for await _ in AsyncStream<Never>.never {}
-      throw _Concurrency.CancellationError()
+extension Task where Failure == Never {
+  /// Waits for the result of the task, propagating cancellation to the task.
+  ///
+  /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+  public var cancellableValue: Success {
+    get async {
+      await withTaskCancellationHandler {
+        await self.value
+      } onCancel: {
+        self.cancel()
+      }
     }
   }
-#endif
+}
 
-#if compiler(>=6.2)
-  extension Task where Failure == Never {
-    /// Waits for the result of the task, propagating cancellation to the task.
-    ///
-    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-    public nonisolated(nonsending) var cancellableValue: Success {
-      get async {
-        await withTaskCancellationHandler {
-          await self.value
-        } onCancel: {
-          self.cancel()
-        }
+extension Task where Failure == Error {
+  /// Waits for the result of the task, propagating cancellation to the task.
+  ///
+  /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+  public var cancellableValue: Success {
+    get async throws {
+      try await withTaskCancellationHandler {
+        try await self.value
+      } onCancel: {
+        self.cancel()
       }
     }
   }
-
-  extension Task where Failure == Error {
-    /// Waits for the result of the task, propagating cancellation to the task.
-    ///
-    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-    public nonisolated(nonsending) var cancellableValue: Success {
-      get async throws {
-        try await withTaskCancellationHandler {
-          try await self.value
-        } onCancel: {
-          self.cancel()
-        }
-      }
-    }
-  }
-#else
-  extension Task where Failure == Never {
-    /// Waits for the result of the task, propagating cancellation to the task.
-    ///
-    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-    public var cancellableValue: Success {
-      get async {
-        await withTaskCancellationHandler {
-          await self.value
-        } onCancel: {
-          self.cancel()
-        }
-      }
-    }
-  }
-
-  extension Task where Failure == Error {
-    /// Waits for the result of the task, propagating cancellation to the task.
-    ///
-    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-    public var cancellableValue: Success {
-      get async throws {
-        try await withTaskCancellationHandler {
-          try await self.value
-        } onCancel: {
-          self.cancel()
-        }
-      }
-    }
-  }
-#endif
+}

--- a/Sources/ConcurrencyExtras/Task.swift
+++ b/Sources/ConcurrencyExtras/Task.swift
@@ -1,24 +1,46 @@
 import Foundation
 
-extension Task where Success == Never, Failure == Never {
-  /// Suspends the current task a number of times before resuming with the goal of allowing other
-  /// tasks to start their work.
-  ///
-  /// This function can be used to make flakey async tests less flakey, as described in
-  /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
-  /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
-  /// reliability of async tests, and to make their execution deterministic.
-  public static func megaYield(count: Int = _defaultMegaYieldCount) async {
-    // TODO: Investigate why mega yields are still necessary in TCA's test suite.
-    // guard !uncheckedUseMainSerialExecutor else {
-    //   await Task.yield()
-    //   return
-    // }
-    for _ in 0..<count {
-      await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
+#if compiler(>=6.2)
+  extension Task where Success == Never, Failure == Never {
+    /// Suspends the current task a number of times before resuming with the goal of allowing other
+    /// tasks to start their work.
+    ///
+    /// This function can be used to make flakey async tests less flakey, as described in
+    /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
+    /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
+    /// reliability of async tests, and to make their execution deterministic.
+    public nonisolated(nonsending) static func megaYield(count: Int = _defaultMegaYieldCount) async {
+      // TODO: Investigate why mega yields are still necessary in TCA's test suite.
+      // guard !uncheckedUseMainSerialExecutor else {
+      //   await Task.yield()
+      //   return
+      // }
+      for _ in 0..<count {
+        await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
+      }
     }
   }
-}
+#else
+  extension Task where Success == Never, Failure == Never {
+    /// Suspends the current task a number of times before resuming with the goal of allowing other
+    /// tasks to start their work.
+    ///
+    /// This function can be used to make flakey async tests less flakey, as described in
+    /// [this Swift Forums post](https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304).
+    /// You may, however, prefer to use ``withMainSerialExecutor(operation:)-79jpc`` to improve the
+    /// reliability of async tests, and to make their execution deterministic.
+    public static func megaYield(count: Int = _defaultMegaYieldCount) async {
+      // TODO: Investigate why mega yields are still necessary in TCA's test suite.
+      // guard !uncheckedUseMainSerialExecutor else {
+      //   await Task.yield()
+      //   return
+      // }
+      for _ in 0..<count {
+        await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
+      }
+    }
+  }
+#endif
 
 /// The number of yields `Task.megaYield()` invokes by default.
 ///
@@ -31,50 +53,102 @@ public let _defaultMegaYieldCount = max(
   )
 )
 
-extension Task where Failure == Never {
-  /// An async function that never returns.
-  public static func never() async throws -> Success {
-    for await element in AsyncStream<Success>.never {
-      return element
+#if compiler(>=6.2)
+  extension Task where Failure == Never {
+    /// An async function that never returns.
+    public nonisolated(nonsending) static func never() async throws -> Success {
+      for await element in AsyncStream<Success>.never {
+        return element
+      }
+      throw _Concurrency.CancellationError()
     }
-    throw _Concurrency.CancellationError()
   }
-}
 
-extension Task where Success == Never, Failure == Never {
-  /// An async function that never returns.
-  public static func never() async throws {
-    for await _ in AsyncStream<Never>.never {}
-    throw _Concurrency.CancellationError()
+  extension Task where Success == Never, Failure == Never {
+    /// An async function that never returns.
+    public nonisolated(nonsending) static func never() async throws {
+      for await _ in AsyncStream<Never>.never {}
+      throw _Concurrency.CancellationError()
+    }
   }
-}
+#else
+  extension Task where Failure == Never {
+    /// An async function that never returns.
+    public static func never() async throws -> Success {
+      for await element in AsyncStream<Success>.never {
+        return element
+      }
+      throw _Concurrency.CancellationError()
+    }
+  }
 
-extension Task where Failure == Never {
-  /// Waits for the result of the task, propagating cancellation to the task.
-  ///
-  /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-  public var cancellableValue: Success {
-    get async {
-      await withTaskCancellationHandler {
-        await self.value
-      } onCancel: {
-        self.cancel()
+  extension Task where Success == Never, Failure == Never {
+    /// An async function that never returns.
+    public static func never() async throws {
+      for await _ in AsyncStream<Never>.never {}
+      throw _Concurrency.CancellationError()
+    }
+  }
+#endif
+
+#if compiler(>=6.2)
+  extension Task where Failure == Never {
+    /// Waits for the result of the task, propagating cancellation to the task.
+    ///
+    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+    public nonisolated(nonsending) var cancellableValue: Success {
+      get async {
+        await withTaskCancellationHandler {
+          await self.value
+        } onCancel: {
+          self.cancel()
+        }
       }
     }
   }
-}
 
-extension Task where Failure == Error {
-  /// Waits for the result of the task, propagating cancellation to the task.
-  ///
-  /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
-  public var cancellableValue: Success {
-    get async throws {
-      try await withTaskCancellationHandler {
-        try await self.value
-      } onCancel: {
-        self.cancel()
+  extension Task where Failure == Error {
+    /// Waits for the result of the task, propagating cancellation to the task.
+    ///
+    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+    public nonisolated(nonsending) var cancellableValue: Success {
+      get async throws {
+        try await withTaskCancellationHandler {
+          try await self.value
+        } onCancel: {
+          self.cancel()
+        }
       }
     }
   }
-}
+#else
+  extension Task where Failure == Never {
+    /// Waits for the result of the task, propagating cancellation to the task.
+    ///
+    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+    public var cancellableValue: Success {
+      get async {
+        await withTaskCancellationHandler {
+          await self.value
+        } onCancel: {
+          self.cancel()
+        }
+      }
+    }
+  }
+
+  extension Task where Failure == Error {
+    /// Waits for the result of the task, propagating cancellation to the task.
+    ///
+    /// Equivalent to wrapping a call to `Task.value` in `withTaskCancellationHandler`.
+    public var cancellableValue: Success {
+      get async throws {
+        try await withTaskCancellationHandler {
+          try await self.value
+        } onCancel: {
+          self.cancel()
+        }
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
Enables Swift's `NonisolatedNonsendingByDefault` upcoming feature for package targets when compiling with Swift 6.2 or newer. This lets public async APIs emit `nonisolated(nonsending)` in generated interfaces without spelling the annotation on each declaration.

This covers:

- `Result.init(catching:)`
- `Task.megaYield(count:)`
- both `Task.never()` overloads
- both `Task.cancellableValue` async getters

Verification:

- `xcodebuild test -quiet -workspace ConcurrencyExtras.xcworkspace -scheme ConcurrencyExtras -destination platform=macOS`
- Generated a library-evolution Swift interface with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`; the emitted `.swiftinterface` includes `-enable-upcoming-feature NonisolatedNonsendingByDefault` and `nonisolated(nonsending)` on the public async APIs.