### PR TITLE
Fix for task local trait.

### DIFF
--- a/Sources/ConcurrencyExtrasTestSupport/TaskLocalTrait.swift
+++ b/Sources/ConcurrencyExtrasTestSupport/TaskLocalTrait.swift
@@ -62,7 +62,9 @@
       testCase: Test.Case?,
       performing function: @concurrent () async throws -> Void
     ) async throws {
-      try await taskLocal.withValue(value, operation: function)
+      try await taskLocal.withValue(value) {
+        try await function()
+      }
     }
   }
 #endif


### PR DESCRIPTION
There seems to be a bug in Swift where passing `function` as an argument to `withValue` (instead of opening up a trailing closures) causes whatever isolation is associated with `function` (e.g. `@MainActor`) to not be respected.