### PR TITLE
Update compiler version check in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ for target in package.targets {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
-  #if compiler(>=6.4)
+  #if compiler(>=6.2)
     target.swiftSettings?.append(contentsOf: [
       .treatAllWarnings(as: .error)
     ])


### PR DESCRIPTION
Noticed this while reading the new "TaskLocal test traits" blog post today and checking out some of the recent updates to this project. The `.treatAllWarnings(as:)` API was [added to SPM in Swift 6.2](https://www.swift.org/blog/swift-6.2-released/#precise-warning-control), so we shouldn't have to gate this to a future Swift release.

Update: Just checked a couple of your other projects that were recently updated (swift-dependencies, swift-clocks, swift-debug-snapshots), and it looks like they're also checking for Swift 6.4. Happy to open PRs in those repos, too, or let y'all take care of it when you update them next.